### PR TITLE
chore(docs): full width component playgrounds

### DIFF
--- a/docs/components/overrides/StyleGuide/StyleGuideRenderer.js
+++ b/docs/components/overrides/StyleGuide/StyleGuideRenderer.js
@@ -5,6 +5,8 @@ import cx from 'classnames'
 import Logo from 'rsg-components/Logo'
 import Markdown from 'rsg-components/Markdown'
 
+import FlexGrid from '../../../../packages/FlexGrid/FlexGrid'
+
 const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth }) => ({
   root: {
     backgroundColor: color.baseBackground,
@@ -54,16 +56,32 @@ const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth
   },
 })
 
+const TdsGrid = ({ children }) => (
+  <FlexGrid limitWidth>
+    <FlexGrid.Row>
+      <FlexGrid.Col xs={12}>
+        {children}
+      </FlexGrid.Col>
+    </FlexGrid.Row>
+  </FlexGrid>
+)
+
 export function StyleGuideRenderer({ classes, title, homepageUrl, children, toc, hasSidebar }) {
+  const main = (
+    <main className={cx(hasSidebar && classes.content)}>
+      {children}
+      <footer className={classes.footer}>
+        <Markdown text={`Generated with [React Styleguidist](${homepageUrl})`} />
+      </footer>
+    </main>
+  )
+
   return (
     <div className={cx(classes.root, hasSidebar && classes.hasSidebar)}>
       <a id="styleguidist-top">&nbsp;</a>
-      <main className={classes.content}>
-        {children}
-        <footer className={classes.footer}>
-          <Markdown text={`Generated with [React Styleguidist](${homepageUrl})`} />
-        </footer>
-      </main>
+
+      {hasSidebar ? main : <TdsGrid>{main}</TdsGrid>}
+
       {hasSidebar && (
         <div className={classes.sidebar}>
           <div className={classes.logo}>

--- a/docs/scss/styleguide.scss
+++ b/docs/scss/styleguide.scss
@@ -50,3 +50,14 @@
     border: 1px solid $color-shark;
   }
 }
+
+// Full width container with limited with parent: https://css-tricks.com/full-width-containers-limited-width-parents/
+// Only activate with there is no sidebar
+.rsg--root-1:not(*[class*='rsg--hasSidebar']) .docs_full-width-playground {
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+}

--- a/packages/FlexGrid/Col/Col.md
+++ b/packages/FlexGrid/Col/Col.md
@@ -8,8 +8,8 @@ width will be `6` from the `md` breakpoint and greater, unless you specify a val
 
 Refer to the table in the [**Responsive**](#responsive) section for the breakpoins.
 
-```jsx { "props": { "className": "docs_flex-grid-coloring" } }
-<FlexGrid>
+```jsx { "props": { "className": "docs_full-width-playground docs_flex-grid-coloring" } }
+<FlexGrid limitWidth>
   <FlexGrid.Row>
     <FlexGrid.Col xs={12} md={6}>
       <Box vertical={2}><Text>12 xs, 6 md</Text></Box>
@@ -37,8 +37,8 @@ Refer to the table in the [**Responsive**](#responsive) section for the breakpoi
 
 Move columns to the right using the responsive `offset` props.
 
-```jsx { "props": { "className": "docs_flex-grid-coloring" } }
-<FlexGrid>
+```jsx { "props": { "className": "docs_full-width-playground docs_flex-grid-coloring" } }
+<FlexGrid limitWidth>
   <FlexGrid.Row>
     <FlexGrid.Col xs={4}>
       <Box vertical={2}><Text>4 xs</Text></Box>

--- a/packages/FlexGrid/FlexGrid.md
+++ b/packages/FlexGrid/FlexGrid.md
@@ -1,3 +1,5 @@
+**Use the "Open isolated" button above to view this component in full-width mode.**
+
 The `FlexGrid` system is a thin wrapper over [react-flexbox-grid](https://github.com/roylee0704/react-flexbox-grid),
 which implements [flexboxgrid.css](http://flexboxgrid.com/). It uses a series of rows and columns to layout and align
 content 2-dimensionally.
@@ -8,7 +10,7 @@ for background, terminology, guidelines, and code snippets.**
 Below is a quick example of how the components fit together. See the [FlexGrid.Row](#row) and [FlexGrid.Col](#col)
 components below for a more in-depth look.
 
-```jsx { "props": { "className": "docs_flex-grid-coloring" } }
+```jsx { "props": { "className": "docs_full-width-playground docs_flex-grid-coloring" } }
 <FlexGrid limitWidth>
   <FlexGrid.Row>
     <FlexGrid.Col>
@@ -40,8 +42,8 @@ components below for a more in-depth look.
 Remove the 16px gutter surrounding columns by passing `gutter={false}` to the `FlexGrid` container. This removes the horizontal padding
 from all children columns.
 
-```jsx { "props": { "className": "docs_flex-grid-coloring" } }
-<FlexGrid gutter={false}>
+```jsx { "props": { "className": "docs_full-width-playground docs_flex-grid-coloring" } }
+<FlexGrid limitWidth gutter={false}>
   <FlexGrid.Row>
     <FlexGrid.Col>
       <Box vertical={2}><Text>1/3 no gutter</Text></Box>

--- a/packages/FlexGrid/Row/Row.md
+++ b/packages/FlexGrid/Row/Row.md
@@ -2,8 +2,8 @@
 
 Use flexbox alignment properties to vertically and horizontally align columns.
 
-```jsx { "props": { "className": "docs_flex-grid-coloring" } }
-<FlexGrid>
+```jsx { "props": { "className": "docs_full-width-playground docs_flex-grid-coloring" } }
+<FlexGrid limitWidth>
   <FlexGrid.Row horizontalAlign="start">
     <FlexGrid.Col xs={4} md={2}>
       <Box vertical={2}><Text>Left</Text></Box>
@@ -33,8 +33,8 @@ Use flexbox alignment properties to vertically and horizontally align columns.
 </FlexGrid>
 ```
 
-```jsx { "props": { "className": "docs_flex-grid-coloring" } }
-<FlexGrid>
+```jsx { "props": { "className": "docs_full-width-playground docs_flex-grid-coloring" } }
+<FlexGrid limitWidth>
   <FlexGrid.Row verticalAlign="top">
     <FlexGrid.Col>
       <Box vertical={2}>
@@ -80,8 +80,8 @@ Use flexbox alignment properties to vertically and horizontally align columns.
 
 Use flexbox distribution properties to control the negative space around columns.
 
-```jsx { "props": { "className": "docs_flex-grid-coloring" } }
-<FlexGrid>
+```jsx { "props": { "className": "docs_full-width-playground docs_flex-grid-coloring" } }
+<FlexGrid limitWidth>
   <FlexGrid.Row distribute="around">
     <FlexGrid.Col xs={3}>
       <Box vertical={2}><Text>Around</Text></Box>

--- a/packages/Notification/Notification.md
+++ b/packages/Notification/Notification.md
@@ -4,7 +4,7 @@ The Notification spans the entire width of the screen, and aligns the message wi
 
 By default, notifications will be displayed in the `instructional` variant.
 
-```jsx
+```jsx { "props": { "className": "docs_full-width-playground" } }
 <Notification>
   <Text bold>Tip:</Text> The services are best suited for larger business organizations ordering
   more than 50 plans on one account.
@@ -25,7 +25,7 @@ Use the `variant` prop to alter the Notification's appearance.
 
 Use the `branded` variant for feedback or chat related messages.
 
-```jsx
+```jsx { "props": { "className": "docs_full-width-playground" } }
 <Notification variant="branded">
   <Text bold>Tell us what you think.</Text> It’s in our nature to listen. As TELUS.com continues to
   evolve, we’d love to <Link href="http://telus.com">hear more from you</Link>.
@@ -37,7 +37,7 @@ Use the `branded` variant for feedback or chat related messages.
 Use the `success` variant to provide feedback of a successful transaction. **The message will include an icon and will
 appear bold to indicate its importance.**
 
-```jsx
+```jsx { "props": { "className": "docs_full-width-playground" } }
 <Notification variant="success">Your password has been successfully changed.</Notification>
 ```
 
@@ -46,7 +46,7 @@ appear bold to indicate its importance.**
 Use the `error` variant to provide feedback of a failed transaction. **The message will include an icon and will appear
 bold to indicate its importance.**
 
-```jsx
+```jsx { "props": { "className": "docs_full-width-playground" } }
 <Notification variant="error">
   Looks like our registration system is temporarily down. You’ll need to come back another time to
   register for My Account. In the meantime, return to <Link href="http://telus.com">TELUS.com</Link>.

--- a/packages/Notification/Notification.md
+++ b/packages/Notification/Notification.md
@@ -1,6 +1,6 @@
-## Minimal usage
+**Use the "Open isolated" button above to view this component in full-width mode.**
 
-The Notification spans the entire width of the screen, and aligns the message with the page content.
+The `Notification` spans the entire width of the screen, and aligns the message with the page content.
 
 By default, notifications will be displayed in the `instructional` variant.
 


### PR DESCRIPTION
This is a WIP. What do you all think?

Adding the `docs_full-width-playground` class to component playgrounds will cause it to "break out" of it's parent container and display the component using the full browser width. This will allow us to better showcase full width components such as `Notification` or `FlexGrid`.

It is not active when the sidebar is being shown:


![screen shot 2018-04-11 at 5 22 22 pm](https://user-images.githubusercontent.com/1375942/38643954-f504d4e4-3dac-11e8-9d11-40cffd51cdb8.png)


And it is active when the sidebar is hidden:

![screen shot 2018-04-11 at 5 22 37 pm](https://user-images.githubusercontent.com/1375942/38643957-f86c099a-3dac-11e8-949e-fb60e67bcf70.png)

I briefly attempted other strategies, but this one seemed to be the most straightforward one, even though it does involve some fancy/potentially brittle CSS.