### PR TITLE
fix(shared-form-field): call onchange after async setstate

### DIFF
--- a/shared/components/FormField/FormField.jsx
+++ b/shared/components/FormField/FormField.jsx
@@ -88,13 +88,18 @@ class FormField extends React.Component {
   onChange = event => {
     const { onChange } = this.props
 
-    this.setState({
-      value: event.target.value,
-    })
+    event.persist()
 
-    if (onChange) {
-      onChange(event)
-    }
+    this.setState(
+      {
+        value: event.target.value,
+      },
+      () => {
+        if (onChange) {
+          onChange(event)
+        }
+      }
+    )
   }
 
   onFocus = event => {


### PR DESCRIPTION
...fixes a race condition when consumers modify the input, such as formatting.

Re: #606 

This fixes an issue brought up by @ah-arch when applying formatting to input fields, specifically when preventing certain characters from being typed. A sample test case of this that will work within styleguidist is:

```jsx
initialState = {
  value: ''
}

const numbersOnly = event => {
  const noAlpha = event.target.value.replace(/[a-z]/g, "");  
  setState({ value: noAlpha })
}

<Input
  label="Phone number"
  value={state.value}
  onChange={numbersOnly}
/>
```

Before this PR, you would briefly see the letters as the user typed. I believe this was due to our use of `setState`  followed by the call to `onChange`. Because `setState` is actually an asynchronous function, its not guaranteed to be called before statements that follow it.

I've switched to using the form of `setState` that supports `updater` callbacks that are guaranteed to be called AFTER the component is updated.

More info here: https://reactjs.org/docs/react-component.html#setstate

Unfortunately, I wasn't able to reproduce the defect with a test due to the timing nature.

---

### Prepr output

```
Changes:
 - @tds/core-input: 1.0.3 => 1.0.4
 - @tds/core-select: 1.0.4 => 1.0.5
 - @tds/core-text-area: 1.0.3 => 1.0.4
 - @tds/shared-form-field: 1.0.3 => 1.0.4 (private)
```