### PR TITLE
chore(config): add all folders to commitlint scopes

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,15 +5,15 @@ const packages = require('@commitlint/config-lerna-scopes')
 const applyCustomScope = () => {
   const customScope = packages.rules[`scope-enum`]()[2]
   customScope.push(
-    'build',
+    'config',
     'dependencies',
     'docs',
     'e2e',
     'github',
     'guide',
-    'tech-snacks',
-    'lint',
-    'scaffolding',
+    'openshift',
+    'other',
+    'scripts',
     'shared'
   )
   return customScope


### PR DESCRIPTION
In an effort to clean up the commitlint, I've added all our top level folders as commit lint scopes. So we could follow these standards:

* If touching a component/package, use that as the scope: `feat(core-button): ...` or `chore(shared-animations): ...`
* If not, use the most directly affected folder: `test(e2e): ...`
* Use "dependencies" when adding/removing/updating dependencies: `chore(dependencies): ...`
* Many of the files in the root are configuration files that would also use the "config" scope, such as ".babelrc" or "commitlint.config.js"
* If nothing else fits, use "other": `chore(other): ...`


I think this should cover all use cases, and we shouldn't need to modify the scopes unless we change folder structure.