### PR TITLE
chore(github): add front matter to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect_template.md
+++ b/.github/ISSUE_TEMPLATE/defect_template.md
@@ -1,3 +1,8 @@
+---
+name: Defect report
+about: Create a report to help us improve
+---
+
 <!--
   ### IMPORTANT SECURITY NOTE ###
 

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,3 +1,8 @@
+---
+name: Feature request
+about: Suggest an idea for tds-core
+---
+
 <!--
   ### IMPORTANT SECURITY NOTE ###
 


### PR DESCRIPTION
- add front matter to issue templates so that GitHub can detect them as official issue templates and leverage the new issue opening experience: https://help.github.com/articles/creating-issue-templates-for-your-repository/