### PR TITLE
fix(core-notification): make notification flex grid gutterless

### DIFF
--- a/packages/Notification/Notification.jsx
+++ b/packages/Notification/Notification.jsx
@@ -32,7 +32,7 @@ const renderIcon = icon => <DecorativeIcon symbol={icon.symbol} variant={icon.co
  */
 const Notification = ({ variant, children, ...rest }) => (
   <Box {...safeRest(rest)} vertical={3} dangerouslyAddClassName={styles[variant]}>
-    <FlexGrid limitWidth>
+    <FlexGrid limitWidth gutter={false}>
       <FlexGrid.Row>
         <FlexGrid.Col>
           <Box inline between={3}>

--- a/packages/Notification/__tests__/__snapshots__/Notification.spec.jsx.snap
+++ b/packages/Notification/__tests__/__snapshots__/Notification.spec.jsx.snap
@@ -11,7 +11,7 @@ exports[`<Notification /> renders 1`] = `
       class="TDS_Row-modules__flexRow___3CHOR TDS_flexboxgrid2__row___3YyB2"
     >
       <div
-        class="TDS_flexboxgrid2__col-xs___2KrHO TDS_Col-modules__padding___2tLQS"
+        class="TDS_flexboxgrid2__col-xs___2KrHO TDS_Col-modules__gutterless___11Fxy"
       >
         <div
           class="TDS_Box-modules__betweenRightMargin-3___1dOvx TDS_Box-modules__inline___jTHcz"


### PR DESCRIPTION
This fixes an issue where notification text will not line up with the rest of the page's text.

Changes:
 - `@tds/core-notification`: 1.1.0 => 1.1.1